### PR TITLE
Define transitive for jakarta.ws.rs 

### DIFF
--- a/base/src/moditect/module-info.java
+++ b/base/src/moditect/module-info.java
@@ -9,6 +9,6 @@ module com.fasterxml.jackson.jaxrs.base {
     requires com.fasterxml.jackson.core;
     requires com.fasterxml.jackson.databind;
 
-    requires static jakarta.ws.rs;
-    requires static jakarta.ws.rs.api;
+    requires transitive jakarta.ws.rs;
+    requires transitive jakarta.ws.rs.api;
 }

--- a/json/src/moditect/module-info.java
+++ b/json/src/moditect/module-info.java
@@ -12,9 +12,6 @@ module com.fasterxml.jackson.jakarta.rs.json {
 
     requires com.fasterxml.jackson.jakarta.rs.base;
 
-    requires static jakarta.ws.rs;
-    requires static jakarta.ws.rs.api;
-
     provides jakarta.ws.rs.ext.MessageBodyReader with
         com.fasterxml.jackson.jakarta.rs.json.JacksonJsonProvider;
     provides jakarta.ws.rs.ext.MessageBodyWriter with

--- a/smile/src/moditect/module-info.java
+++ b/smile/src/moditect/module-info.java
@@ -11,9 +11,6 @@ module com.fasterxml.jackson.jakarta.rs.smile {
 
     requires com.fasterxml.jackson.jakarta.rs.base;
 
-    requires static jakarta.ws.rs;
-    requires static jakarta.ws.rs.api;
-
     provides jakarta.ws.rs.ext.MessageBodyReader with
         com.fasterxml.jackson.jakarta.rs.smile.JacksonSmileProvider;
     provides jakarta.ws.rs.ext.MessageBodyWriter with

--- a/xml/src/moditect/module-info.java
+++ b/xml/src/moditect/module-info.java
@@ -11,9 +11,6 @@ module com.fasterxml.jackson.jakarta.rs.xml {
 
     requires com.fasterxml.jackson.jakarta.rs.base;
 
-    requires static jakarta.ws.rs;
-    requires static jakarta.ws.rs.api;
-
     provides jakarta.ws.rs.ext.MessageBodyReader with
         com.fasterxml.jackson.jakarta.rs.xml.JacksonXMLProvider;
     provides jakarta.ws.rs.ext.MessageBodyWriter with

--- a/yaml/src/moditect/module-info.java
+++ b/yaml/src/moditect/module-info.java
@@ -11,9 +11,6 @@ module com.fasterxml.jackson.jakarta.rs.yaml {
 
     requires com.fasterxml.jackson.jakarta.rs.base;
 
-    requires static jakarta.ws.rs;
-    requires static jakarta.ws.rs.api;
-
     provides jakarta.ws.rs.ext.MessageBodyReader with
         com.fasterxml.jackson.jakarta.rs.yaml.JacksonYAMLProvider;
     provides jakarta.ws.rs.ext.MessageBodyWriter with


### PR DESCRIPTION
Use the base module as the transitive definition for all the other modules, leave the jackson modules as independently defined

I thought this would be good?