### PR TITLE
Add `JakartaRsFeature.READ_FULL_STREAM` to consume all content, on by default

### DIFF
--- a/base/src/main/java/com/fasterxml/jackson/jakarta/rs/base/ProviderBase.java
+++ b/base/src/main/java/com/fasterxml/jackson/jakarta/rs/base/ProviderBase.java
@@ -438,6 +438,9 @@ public abstract class ProviderBase<
         } else {
             r = mapper.reader();
         }
+        if (JakartaRSFeature.READ_FULL_STREAM.enabledIn(_jakartaRSFeatures)) {
+            r = r.withFeatures(DeserializationFeature.FAIL_ON_TRAILING_TOKENS);
+        }
         return _configForReading(r, annotations);
     }
 

--- a/base/src/main/java/com/fasterxml/jackson/jakarta/rs/cfg/JakartaRSFeature.java
+++ b/base/src/main/java/com/fasterxml/jackson/jakarta/rs/cfg/JakartaRSFeature.java
@@ -24,6 +24,14 @@ public enum JakartaRSFeature implements ConfigFeature
      */
     ALLOW_EMPTY_INPUT(true),
 
+    /**
+     * For HTTP keep-alive or multipart content to work correctly, Jackson must read the entire HTTP input
+     * stream up until reading EOF (-1).
+     * <a href="https://github.com/FasterXML/jackson-jaxrs-providers/issues/108">Issue #108</a>
+     * If set to true, always consume all input content. This has a side-effect of failing on trailing content.
+     */
+    READ_FULL_STREAM(true),
+
     /*
     /**********************************************************************
     /* HTTP headers


### PR DESCRIPTION
See https://github.com/FasterXML/jackson-jaxrs-providers/issues/108