### PR TITLE
upgrade to resteasy 4.7.9

### DIFF
--- a/json/pom.xml
+++ b/json/pom.xml
@@ -65,7 +65,7 @@
     <dependency> 
       <groupId>org.jboss.resteasy</groupId>
       <artifactId>resteasy-jackson2-provider</artifactId>
-      <version>6.2.3,Final</version>
+      <version>6.2.3.Final</version>
       <scope>test</scope>
 <!--
       <exclusions>

--- a/json/pom.xml
+++ b/json/pom.xml
@@ -65,7 +65,7 @@
     <dependency> 
       <groupId>org.jboss.resteasy</groupId>
       <artifactId>resteasy-jackson2-provider</artifactId>
-      <version>6.2.3.Final</version>
+      <version>4.7.9.Final</version>
       <scope>test</scope>
 <!--
       <exclusions>
@@ -82,7 +82,7 @@ https://stackoverflow.com/questions/44088493/jersey-stopped-working-with-injecti
     <dependency>
       <groupId>org.jboss.resteasy</groupId>
       <artifactId>resteasy-client</artifactId>
-      <version>6.2.3.Final</version>
+      <version>4.7.9.Final</version>
       <scope>test</scope>
 <!--
       <exclusions>

--- a/json/pom.xml
+++ b/json/pom.xml
@@ -65,7 +65,7 @@
     <dependency> 
       <groupId>org.jboss.resteasy</groupId>
       <artifactId>resteasy-jackson2-provider</artifactId>
-      <version>4.6.0.Final</version>
+      <version>6.2.3,Final</version>
       <scope>test</scope>
 <!--
       <exclusions>
@@ -82,7 +82,7 @@ https://stackoverflow.com/questions/44088493/jersey-stopped-working-with-injecti
     <dependency>
       <groupId>org.jboss.resteasy</groupId>
       <artifactId>resteasy-client</artifactId>
-      <version>4.6.0.Final</version>
+      <version>6.2.3.Final</version>
       <scope>test</scope>
 <!--
       <exclusions>


### PR DESCRIPTION
* recently released
* resteasy 6 actually supports jakarta-rs while resteasy 4 is for jaxrs but it looks like some changes need to be made to this lib to support resteasy 6 (test failures)