### PR TITLE
Fix flaky tests

### DIFF
--- a/base/src/test/java/com/fasterxml/jackson/jakarta/rs/base/cfg/AnnotationBundleKeyTest.java
+++ b/base/src/test/java/com/fasterxml/jackson/jakarta/rs/base/cfg/AnnotationBundleKeyTest.java
@@ -1,6 +1,8 @@
 package com.fasterxml.jackson.jakarta.rs.base.cfg;
 
 import java.lang.annotation.Annotation;
+import java.util.Arrays;
+import java.util.Comparator;
 
 import com.fasterxml.jackson.annotation.*;
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
@@ -86,6 +88,8 @@ public class AnnotationBundleKeyTest
         if (anns1.length == 0) {
             fail("Internal error: empty annotation array");
         }
+        Arrays.sort(anns1, Comparator.comparing(Annotation::toString));
+        Arrays.sort(anns2, Comparator.comparing(Annotation::toString));
         assertArrayEquals("Internal error: should never differ", anns1, anns2);
 
         AnnotationBundleKey b1 = new AnnotationBundleKey(anns1, Object.class);


### PR DESCRIPTION
This PR is to fix 2 flaky tests `com.fasterxml.jackson.jakarta.rs.base.cfg.AnnotationBundleKeyTest#testWithMethodAnnotationEquals` and `com.fasterxml.jackson.jakarta.rs.base.cfg.AnnotationBundleKeyTest#testWithClassAnnotations` in mudule `base`. We will take one of them as the example in the following description.

### Reproduce test failures
- Run the following commands to reproduce test failures:
```
mvn  edu.illinois:nondex-maven-plugin:2.1.1:nondex -pl base -Dtest=com.fasterxml.jackson.jakarta.rs.base.cfg.AnnotationBundleKeyTest#testWithClassAnnotations
```
- Then we will get the following test failures:
```
 AnnotationBundleKeyTest.testWithClassAnnotations:45->_checkWith:89 Internal error: should never differ: arrays first differed at element [0]; expected:<@com.fasterxml.jackson.annotation.JsonIgnoreProperties(value=[], allowGetters=false, allowSetters=false, ignoreUnknown=false)> but was:<@com.fasterxml.jackson.databind.annotation.JsonDeserialize(keyUsing=class com.fasterxml.jackson.databind.KeyDeserializer$None, as=class java.lang.Void, using=class com.fasterxml.jackson.databind.JsonDeserializer$None, contentUsing=class com.fasterxml.jackson.databind.JsonDeserializer$None, keyAs=class java.lang.Void, contentConverter=class com.fasterxml.jackson.databind.util.Converter$None, builder=class java.lang.Void, converter=class com.fasterxml.jackson.databind.util.Converter$None, contentAs=class java.lang.Void)>
```
### Root cause and fix
In these tests, assertions are comparing 2 arrays of `Annotation` returned by the method `getAnnotations()`. However, `getAnnotations()` can not guarantee to return items of the array in the same order, which will lead to test failures. To fix the flakiness, we should sort the arrays in `_checkWith` before comparing them.