### PR TITLE
Replace synchronized blocks with `ReentrantLock`s

### DIFF
--- a/base/src/main/java/com/fasterxml/jackson/jakarta/rs/cfg/MapperConfiguratorBase.java
+++ b/base/src/main/java/com/fasterxml/jackson/jakarta/rs/cfg/MapperConfiguratorBase.java
@@ -81,27 +81,27 @@ public abstract class MapperConfiguratorBase<IMPL extends MapperConfiguratorBase
     /**********************************************************************
      */
 
-    public synchronized final void setMapper(MAPPER m) {
+    public final void setMapper(MAPPER m) {
         _mapper = m;
     }
 
-    public synchronized final void setAnnotationsToUse(Annotations[] annotationsToUse) {
+    public final void setAnnotationsToUse(Annotations[] annotationsToUse) {
         _setAnnotations(mapper(), annotationsToUse);
     }
 
-    public synchronized final void configure(DeserializationFeature f, boolean state) {
+    public final void configure(DeserializationFeature f, boolean state) {
         mapper().configure(f, state);
     }
 
-    public synchronized final void configure(SerializationFeature f, boolean state) {
+    public final void configure(SerializationFeature f, boolean state) {
         mapper().configure(f, state);
     }
 
-    public synchronized final void configure(JsonParser.Feature f, boolean state) {
+    public final void configure(JsonParser.Feature f, boolean state) {
         mapper().configure(f, state);
     }
 
-    public synchronized final void configure(JsonGenerator.Feature f, boolean state) {
+    public final void configure(JsonGenerator.Feature f, boolean state) {
         mapper().configure(f, state);
     }
 

--- a/cbor/src/main/java/com/fasterxml/jackson/jakarta/rs/cbor/CBORMapperConfigurator.java
+++ b/cbor/src/main/java/com/fasterxml/jackson/jakarta/rs/cbor/CBORMapperConfigurator.java
@@ -1,6 +1,7 @@
 package com.fasterxml.jackson.jakarta.rs.cbor;
 
 import java.util.*;
+import java.util.concurrent.locks.ReentrantLock;
 
 import com.fasterxml.jackson.databind.*;
 import com.fasterxml.jackson.databind.introspect.JacksonAnnotationIntrospector;
@@ -19,6 +20,8 @@ import com.fasterxml.jackson.module.jakarta.xmlbind.JakartaXmlBindAnnotationIntr
 public class CBORMapperConfigurator
     extends MapperConfiguratorBase<CBORMapperConfigurator, ObjectMapper>
 {
+    private final ReentrantLock _lock = new ReentrantLock();
+
     public CBORMapperConfigurator(ObjectMapper mapper, Annotations[] defAnnotations)
     {
         super(mapper, defAnnotations);
@@ -28,17 +31,24 @@ public class CBORMapperConfigurator
      * Method that locates, configures and returns {@link ObjectMapper} to use
      */
     @Override
-    public synchronized ObjectMapper getConfiguredMapper() {
+    public ObjectMapper getConfiguredMapper() {
         // important: should NOT call mapper(); needs to return null
         // if no instance has been passed or constructed
         return _mapper;
     }
 
     @Override
-    public synchronized ObjectMapper getDefaultMapper() {
+    public ObjectMapper getDefaultMapper() {
         if (_defaultMapper == null) {
-            _defaultMapper = new ObjectMapper(new CBORFactory());
-            _setAnnotations(_defaultMapper, _defaultAnnotationsToUse);
+            _lock.lock();
+            try {
+                if (_defaultMapper == null) {
+                    _defaultMapper = new ObjectMapper(new CBORFactory());
+                    _setAnnotations(_defaultMapper, _defaultAnnotationsToUse);
+                }
+            } finally {
+                _lock.unlock();
+            }
         }
         return _defaultMapper;
     }
@@ -58,8 +68,15 @@ public class CBORMapperConfigurator
     protected ObjectMapper mapper()
     {
         if (_mapper == null) {
-            _mapper = new ObjectMapper(new CBORFactory());
-            _setAnnotations(_mapper, _defaultAnnotationsToUse);
+            _lock.lock();
+            try {
+                if (_mapper == null) {
+                    _mapper = new ObjectMapper(new CBORFactory());
+                    _setAnnotations(_mapper, _defaultAnnotationsToUse);
+                }
+            } finally {
+                _lock.unlock();
+            }
         }
         return _mapper;
     }

--- a/json/src/main/java/com/fasterxml/jackson/jakarta/rs/json/JsonMapperConfigurator.java
+++ b/json/src/main/java/com/fasterxml/jackson/jakarta/rs/json/JsonMapperConfigurator.java
@@ -1,6 +1,7 @@
 package com.fasterxml.jackson.jakarta.rs.json;
 
 import java.util.*;
+import java.util.concurrent.locks.ReentrantLock;
 
 import com.fasterxml.jackson.databind.*;
 import com.fasterxml.jackson.databind.introspect.JacksonAnnotationIntrospector;
@@ -18,6 +19,8 @@ import com.fasterxml.jackson.jakarta.rs.cfg.MapperConfiguratorBase;
 public class JsonMapperConfigurator
     extends MapperConfiguratorBase<JsonMapperConfigurator, ObjectMapper>
 {
+    private final ReentrantLock _lock = new ReentrantLock();
+
     public JsonMapperConfigurator(ObjectMapper mapper, Annotations[] defAnnotations)
     {
         super(mapper, defAnnotations);
@@ -27,7 +30,7 @@ public class JsonMapperConfigurator
      * Method that locates, configures and returns {@link ObjectMapper} to use
      */
     @Override
-    public synchronized ObjectMapper getConfiguredMapper() {
+    public ObjectMapper getConfiguredMapper() {
         /* important: should NOT call mapper(); needs to return null
          * if no instance has been passed or constructed
          */
@@ -35,10 +38,17 @@ public class JsonMapperConfigurator
     }
 
     @Override
-    public synchronized ObjectMapper getDefaultMapper() {
+    public ObjectMapper getDefaultMapper() {
         if (_defaultMapper == null) {
-            _defaultMapper = new ObjectMapper();
-            _setAnnotations(_defaultMapper, _defaultAnnotationsToUse);
+            _lock.lock();
+            try {
+                if (_defaultMapper == null) {
+                    _defaultMapper = new ObjectMapper();
+                    _setAnnotations(_defaultMapper, _defaultAnnotationsToUse);
+                }
+            } finally {
+                _lock.unlock();
+            }
         }
         return _defaultMapper;
     }
@@ -58,8 +68,15 @@ public class JsonMapperConfigurator
     protected ObjectMapper mapper()
     {
         if (_mapper == null) {
-            _mapper = new ObjectMapper();
-            _setAnnotations(_mapper, _defaultAnnotationsToUse);
+            _lock.lock();
+            try {
+                if (_mapper == null) {
+                    _mapper = new ObjectMapper();
+                    _setAnnotations(_mapper, _defaultAnnotationsToUse);
+                }
+            } finally {
+                _lock.unlock();
+            }
         }
         return _mapper;
     }

--- a/release-notes/CREDITS-2.x
+++ b/release-notes/CREDITS-2.x
@@ -9,6 +9,8 @@ PJ Fanning (@pjfanning)
 * Contributed #12: Remove unnecessary synchronization from endpoint
   reader/writer caches
  (2.14.2)
+* Contributed #26: Replace synchronized blocks with `ReentrantLock`s
+ (2.17.1)
 
 Steven Schlansker (@stevenschlansker)
 

--- a/release-notes/VERSION-2.x
+++ b/release-notes/VERSION-2.x
@@ -10,6 +10,11 @@ Sub-modules:
 === Releases ===
 ------------------------------------------------------------------------
 
+2.17.1 (not yet released)
+
+#26: Replace synchronized blocks with `ReentrantLock`s
+ (contributed by @pjfanning)
+
 2.17.0 (12-Mar-2024)
 
 * Upgrade Woodstox to 6.6.1

--- a/smile/src/main/java/com/fasterxml/jackson/jakarta/rs/smile/SmileMapperConfigurator.java
+++ b/smile/src/main/java/com/fasterxml/jackson/jakarta/rs/smile/SmileMapperConfigurator.java
@@ -1,6 +1,7 @@
 package com.fasterxml.jackson.jakarta.rs.smile;
 
 import java.util.*;
+import java.util.concurrent.locks.ReentrantLock;
 
 import com.fasterxml.jackson.databind.*;
 import com.fasterxml.jackson.databind.introspect.JacksonAnnotationIntrospector;
@@ -20,6 +21,8 @@ import com.fasterxml.jackson.jakarta.rs.cfg.MapperConfiguratorBase;
 public class SmileMapperConfigurator
     extends MapperConfiguratorBase<SmileMapperConfigurator, ObjectMapper>
 {
+    private final ReentrantLock _lock = new ReentrantLock();
+
     public SmileMapperConfigurator(ObjectMapper mapper, Annotations[] defAnnotations) {
         super(mapper, defAnnotations);
     }
@@ -28,17 +31,24 @@ public class SmileMapperConfigurator
      * Method that locates, configures and returns {@link ObjectMapper} to use
      */
     @Override
-    public synchronized ObjectMapper getConfiguredMapper() {
+    public ObjectMapper getConfiguredMapper() {
         // important: should NOT call mapper(); needs to return null
         // if no instance has been passed or constructed
         return _mapper;
     }
 
     @Override
-    public synchronized ObjectMapper getDefaultMapper() {
+    public ObjectMapper getDefaultMapper() {
         if (_defaultMapper == null) {
-            _defaultMapper = new SmileMapper();
-            _setAnnotations(_defaultMapper, _defaultAnnotationsToUse);
+            _lock.lock();
+            try {
+                if (_defaultMapper == null) {
+                    _defaultMapper = new SmileMapper();
+                    _setAnnotations(_defaultMapper, _defaultAnnotationsToUse);
+                }
+            } finally {
+                _lock.unlock();
+            }
         }
         return _defaultMapper;
     }
@@ -58,8 +68,15 @@ public class SmileMapperConfigurator
     protected ObjectMapper mapper()
     {
         if (_mapper == null) {
-            _mapper = new SmileMapper();
-            _setAnnotations(_mapper, _defaultAnnotationsToUse);
+            _lock.lock();
+            try {
+                if (_mapper == null) {
+                    _mapper = new SmileMapper();
+                    _setAnnotations(_mapper, _defaultAnnotationsToUse);
+                }
+            } finally {
+                _lock.unlock();
+            }
         }
         return _mapper;
     }

--- a/xml/src/main/java/com/fasterxml/jackson/jakarta/rs/xml/XMLMapperConfigurator.java
+++ b/xml/src/main/java/com/fasterxml/jackson/jakarta/rs/xml/XMLMapperConfigurator.java
@@ -1,6 +1,7 @@
 package com.fasterxml.jackson.jakarta.rs.xml;
 
 import java.util.*;
+import java.util.concurrent.locks.ReentrantLock;
 
 import com.fasterxml.jackson.databind.*;
 
@@ -20,6 +21,8 @@ import com.fasterxml.jackson.module.jakarta.xmlbind.JakartaXmlBindAnnotationIntr
 public class XMLMapperConfigurator
     extends MapperConfiguratorBase<XMLMapperConfigurator, XmlMapper>
 {
+    private final ReentrantLock _lock = new ReentrantLock();
+
     /*
     /**********************************************************
     /* Construction
@@ -35,7 +38,7 @@ public class XMLMapperConfigurator
      * Method that locates, configures and returns {@link XmlMapper} to use
      */
     @Override
-    public synchronized XmlMapper getConfiguredMapper() {
+    public XmlMapper getConfiguredMapper() {
         /* important: should NOT call mapper(); needs to return null
          * if no instance has been passed or constructed
          */
@@ -43,13 +46,20 @@ public class XMLMapperConfigurator
     }
 
     @Override
-    public synchronized XmlMapper getDefaultMapper()
+    public XmlMapper getDefaultMapper()
     {
         if (_defaultMapper == null) {
-            // 10-Oct-2012, tatu: Better do things explicitly...
-            JacksonXmlModule module = getConfiguredModule();
-            _defaultMapper = (module == null) ? new XmlMapper() : new XmlMapper(module);
-            _setAnnotations(_defaultMapper, _defaultAnnotationsToUse);
+            _lock.lock();
+            try {
+                if (_defaultMapper == null) {
+                    // 10-Oct-2012, tatu: Better do things explicitly...
+                    JacksonXmlModule module = getConfiguredModule();
+                    _defaultMapper = (module == null) ? new XmlMapper() : new XmlMapper(module);
+                    _setAnnotations(_defaultMapper, _defaultAnnotationsToUse);
+                }
+            } finally {
+                _lock.unlock();
+            }
         }
         return _defaultMapper;
     }
@@ -74,8 +84,15 @@ public class XMLMapperConfigurator
     protected XmlMapper mapper()
     {
         if (_mapper == null) {
-            _mapper = new XmlMapper();
-            _setAnnotations(_mapper, _defaultAnnotationsToUse);
+            _lock.lock();
+            try {
+                if (_mapper == null) {
+                    _mapper = new XmlMapper();
+                    _setAnnotations(_mapper, _defaultAnnotationsToUse);
+                }
+            } finally {
+                _lock.unlock();
+            }
         }
         return _mapper;
     }


### PR DESCRIPTION
relates to https://github.com/FasterXML/jackson-jaxrs-providers/pull/184

using ReentrantLocks instead of synchronized block

There is no 2.18 branch so using 2.17 for now