### PR TITLE
mark variables as volatile

### DIFF
--- a/base/src/main/java/com/fasterxml/jackson/jakarta/rs/cfg/MapperConfiguratorBase.java
+++ b/base/src/main/java/com/fasterxml/jackson/jakarta/rs/cfg/MapperConfiguratorBase.java
@@ -19,7 +19,7 @@ public abstract class MapperConfiguratorBase<IMPL extends MapperConfiguratorBase
      * If defined (explicitly or implicitly) it will be used, instead
      * of using provider-based lookup.
      */
-    protected MAPPER _mapper;
+    protected volatile MAPPER _mapper;
 
     /**
      * If no mapper was specified when constructed, and no configuration
@@ -27,13 +27,13 @@ public abstract class MapperConfiguratorBase<IMPL extends MapperConfiguratorBase
      * between default mapper and regular one is that default mapper
      * is only used if no mapper is found via provider lookup.
      */
-    protected MAPPER _defaultMapper;
+    protected volatile MAPPER _defaultMapper;
 
     /**
      * Annotations set to use by default; overridden by explicit call
-     * to {@link #setAnnotationsToUse}
+     * to {@link #setAnnotationsToUse}. Marked final in v2.17.1.
      */
-    protected Annotations[] _defaultAnnotationsToUse;
+    protected final Annotations[] _defaultAnnotationsToUse;
 
     /**
      * To support optional dependency to Jackson Jakarta XmlBind annotations module


### PR DESCRIPTION
If this change is ok I can port it to jackson-jaxrs-providers.

Shared variables that have mutable values are best marked as volatile. The `_defaultAnnotationsToUse` variable is only set in the constructors so it feels best to mark it as `final` to highlight that the value doesn't change and does not need to be `volatile`.