### PR TITLE
Fix ServiceLoader manifests due to package changes

### DIFF
--- a/cbor/src/main/resources/META-INF/services/jakarta.ws.rs.ext.MessageBodyReader
+++ b/cbor/src/main/resources/META-INF/services/jakarta.ws.rs.ext.MessageBodyReader
@@ -1,1 +1,1 @@
-com.fasterxml.jackson.jakarta.rs.cbor.JacksonCBORProvider
+tools.jackson.jakarta.rs.cbor.JacksonCBORProvider

--- a/cbor/src/main/resources/META-INF/services/jakarta.ws.rs.ext.MessageBodyWriter
+++ b/cbor/src/main/resources/META-INF/services/jakarta.ws.rs.ext.MessageBodyWriter
@@ -1,1 +1,1 @@
-com.fasterxml.jackson.jakarta.rs.cbor.JacksonCBORProvider
+tools.jackson.jakarta.rs.cbor.JacksonCBORProvider

--- a/json/src/main/resources/META-INF/services/jakarta.ws.rs.ext.MessageBodyReader
+++ b/json/src/main/resources/META-INF/services/jakarta.ws.rs.ext.MessageBodyReader
@@ -1,1 +1,1 @@
-com.fasterxml.jackson.jakarta.rs.json.JacksonJsonProvider
+tools.jackson.jakarta.rs.json.JacksonJsonProvider

--- a/json/src/main/resources/META-INF/services/jakarta.ws.rs.ext.MessageBodyWriter
+++ b/json/src/main/resources/META-INF/services/jakarta.ws.rs.ext.MessageBodyWriter
@@ -1,1 +1,1 @@
-com.fasterxml.jackson.jakarta.rs.json.JacksonJsonProvider
+tools.jackson.jakarta.rs.json.JacksonJsonProvider

--- a/release-notes/CREDITS
+++ b/release-notes/CREDITS
@@ -1,6 +1,13 @@
 Here are people who have contributed to development Jackson JSON processor
 Jakarta-RS providers module, version 3.x
 (version numbers in brackets indicate release in which the problem was fixed)
+(for Jackson 2.x credits, see CREDITS-2.x)
 
 Tatu Saloranta, tatu.saloranta@iki.fi: author
 
+----------------------------------------------------------------------------
+
+Andriy Redko (@reta)
+
+* Contributed #57: Fix ServiceLoader manifests due to 3.0 package changes
+ [3.0.1]

--- a/release-notes/VERSION
+++ b/release-notes/VERSION
@@ -10,6 +10,11 @@ Sub-modules:
 === Releases ===
 ------------------------------------------------------------------------
 
+3.0.1 (not yet released)
+
+#57: Fix ServiceLoader manifests due to 3.0 package changes
+ (contributed by Andriy R)
+
 3.0.0 (03-Oct-2025)
 
 #43: Change 3.0 to use `module-info.java` directly [JSTEP-11]

--- a/smile/src/main/resources/META-INF/services/jakarta.ws.rs.ext.MessageBodyReader
+++ b/smile/src/main/resources/META-INF/services/jakarta.ws.rs.ext.MessageBodyReader
@@ -1,1 +1,1 @@
-com.fasterxml.jackson.jakarta.rs.smile.JacksonSmileProvider
+tools.jackson.jakarta.rs.smile.JacksonSmileProvider

--- a/smile/src/main/resources/META-INF/services/jakarta.ws.rs.ext.MessageBodyWriter
+++ b/smile/src/main/resources/META-INF/services/jakarta.ws.rs.ext.MessageBodyWriter
@@ -1,1 +1,1 @@
-com.fasterxml.jackson.jakarta.rs.smile.JacksonSmileProvider
+tools.jackson.jakarta.rs.smile.JacksonSmileProvider

--- a/xml/src/main/resources/META-INF/services/jakarta.ws.rs.ext.MessageBodyReader
+++ b/xml/src/main/resources/META-INF/services/jakarta.ws.rs.ext.MessageBodyReader
@@ -1,2 +1,2 @@
-com.fasterxml.jackson.jakarta.rs.xml.JacksonXMLProvider
+tools.jackson.jakarta.rs.xml.JacksonXMLProvider
 

--- a/xml/src/main/resources/META-INF/services/jakarta.ws.rs.ext.MessageBodyWriter
+++ b/xml/src/main/resources/META-INF/services/jakarta.ws.rs.ext.MessageBodyWriter
@@ -1,1 +1,1 @@
-com.fasterxml.jackson.jakarta.rs.xml.JacksonXMLProvider
+tools.jackson.jakarta.rs.xml.JacksonXMLProvider

--- a/yaml/src/main/resources/META-INF/services/jakarta.ws.rs.ext.MessageBodyReader
+++ b/yaml/src/main/resources/META-INF/services/jakarta.ws.rs.ext.MessageBodyReader
@@ -1,2 +1,2 @@
-com.fasterxml.jackson.jakarta.rs.yaml.JacksonYAMLProvider
+tools.jackson.jakarta.rs.yaml.JacksonYAMLProvider
 

--- a/yaml/src/main/resources/META-INF/services/jakarta.ws.rs.ext.MessageBodyWriter
+++ b/yaml/src/main/resources/META-INF/services/jakarta.ws.rs.ext.MessageBodyWriter
@@ -1,1 +1,1 @@
-com.fasterxml.jackson.jakarta.rs.yaml.JacksonYAMLProvider
+tools.jackson.jakarta.rs.yaml.JacksonYAMLProvider


### PR DESCRIPTION
Fix JDK `ServiceLoader` manifests due to package changes. 

```
Caused by: java.util.ServiceConfigurationError: jakarta.ws.rs.ext.MessageBodyWriter: Provider com.fasterxml.jackson.jakarta.rs.json.JacksonJsonProvider not found
        at java.base/java.util.ServiceLoader.fail(ServiceLoader.java:559)
        at java.base/java.util.ServiceLoader$LazyClassPathLookupIterator.nextProviderClass(ServiceLoader.java:1090)
        at java.base/java.util.ServiceLoader$LazyClassPathLookupIterator.hasNextService(ServiceLoader.java:1099)
        at java.base/java.util.ServiceLoader$LazyClassPathLookupIterator.hasNext(ServiceLoader.java:1142)
        at java.base/java.util.ServiceLoader$1.hasNext(ServiceLoader.java:1164)
        at java.base/java.util.ServiceLoader$2.hasNext(ServiceLoader.java:1246)
        at org.apache.cxf.cdi.JAXRSCdiResourceExtension.loadExternalProviders(JAXRSCdiResourceE
```

Version `3.0.0` (applicable to `3.x` release line only)