### PR TITLE
Create SPI metadata verification (unit) test

### DIFF
--- a/cbor/src/test/java/module-info.java
+++ b/cbor/src/test/java/module-info.java
@@ -24,4 +24,8 @@ module tools.jackson.jakarta.rs.cbor
     opens tools.jackson.jakarta.rs.cbor;
     opens tools.jackson.jakarta.rs.cbor.dw;
     opens tools.jackson.jakarta.rs.cbor.jersey;
+
+    // ServiceLoader tests
+    uses jakarta.ws.rs.ext.MessageBodyWriter;
+    uses jakarta.ws.rs.ext.MessageBodyReader;
 }

--- a/cbor/src/test/java/tools/jackson/jakarta/rs/cbor/ServiceLoaderIT.java
+++ b/cbor/src/test/java/tools/jackson/jakarta/rs/cbor/ServiceLoaderIT.java
@@ -1,0 +1,49 @@
+package tools.jackson.jakarta.rs.cbor;
+
+import java.util.Comparator;
+import java.util.List;
+import java.util.ServiceLoader;
+import java.util.ServiceLoader.Provider;
+
+import jakarta.ws.rs.ext.MessageBodyReader;
+import jakarta.ws.rs.ext.MessageBodyWriter;
+
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+public class ServiceLoaderIT {
+    @Test
+    public void testMessageBodyWriter() {
+        @SuppressWarnings("rawtypes")
+        final List<MessageBodyWriter> providers = ServiceLoader
+            .load(MessageBodyWriter.class)
+            .stream()
+            .map(Provider<MessageBodyWriter>::get)
+            .toList();
+
+        assertEquals(providers
+            .stream()
+            .map(w -> w.getClass())
+            .sorted(Comparator.comparing(Class::getSimpleName)).toList(), List.of(
+                tools.jackson.jakarta.rs.cbor.JacksonCBORProvider.class
+            ));
+    }
+
+    @Test
+    public void testMessageBodyReader() {
+        @SuppressWarnings("rawtypes")
+        final List<MessageBodyReader> providers = ServiceLoader
+            .load(MessageBodyReader.class)
+            .stream()
+            .map(Provider<MessageBodyReader>::get)
+            .toList();
+
+        assertEquals(providers
+            .stream()
+            .map(w -> w.getClass())
+            .sorted(Comparator.comparing(Class::getSimpleName)).toList(), List.of(
+                tools.jackson.jakarta.rs.cbor.JacksonCBORProvider.class
+            ));
+    }
+}

--- a/json/src/test/java/module-info.java
+++ b/json/src/test/java/module-info.java
@@ -27,4 +27,8 @@ module tools.jackson.jakarta.rs.json
     opens tools.jackson.jakarta.rs.json.resteasy;
     opens tools.jackson.jakarta.rs.json.testutil;
     opens tools.jackson.jakarta.rs.json.util;
+
+    // ServiceLoader tests
+    uses jakarta.ws.rs.ext.MessageBodyWriter;
+    uses jakarta.ws.rs.ext.MessageBodyReader;
 }

--- a/json/src/test/java/tools/jackson/jakarta/rs/json/ServiceLoaderIT.java
+++ b/json/src/test/java/tools/jackson/jakarta/rs/json/ServiceLoaderIT.java
@@ -1,0 +1,49 @@
+package tools.jackson.jakarta.rs.json;
+
+import java.util.Comparator;
+import java.util.List;
+import java.util.ServiceLoader;
+import java.util.ServiceLoader.Provider;
+
+import jakarta.ws.rs.ext.MessageBodyReader;
+import jakarta.ws.rs.ext.MessageBodyWriter;
+
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+public class ServiceLoaderIT {
+    @Test
+    public void testMessageBodyWriter() {
+        @SuppressWarnings("rawtypes")
+        final List<MessageBodyWriter> providers = ServiceLoader
+            .load(MessageBodyWriter.class)
+            .stream()
+            .map(Provider<MessageBodyWriter>::get)
+            .toList();
+
+        assertEquals(providers
+            .stream()
+            .map(w -> w.getClass())
+            .sorted(Comparator.comparing(Class::getSimpleName)).toList(), List.of(
+                tools.jackson.jakarta.rs.json.JacksonJsonProvider.class
+            ));
+    }
+
+    @Test
+    public void testMessageBodyReader() {
+        @SuppressWarnings("rawtypes")
+        final List<MessageBodyReader> providers = ServiceLoader
+            .load(MessageBodyReader.class)
+            .stream()
+            .map(Provider<MessageBodyReader>::get)
+            .toList();
+
+        assertEquals(providers
+            .stream()
+            .map(w -> w.getClass())
+            .sorted(Comparator.comparing(Class::getSimpleName)).toList(), List.of(
+                tools.jackson.jakarta.rs.json.JacksonJsonProvider.class
+            ));
+    }
+}

--- a/pom.xml
+++ b/pom.xml
@@ -158,6 +158,24 @@ https://stackoverflow.com/questions/44088493/jersey-stopped-working-with-injecti
   </repositories>  
 
   <build>
+    <plugins>
+      <!-- ServiceLoader tests -->
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-failsafe-plugin</artifactId>
+        <configuration>
+          <useModulePath>false</useModulePath>
+        </configuration>
+        <executions>
+          <execution>
+            <goals>
+              <goal>integration-test</goal>
+              <goal>verify</goal>
+            </goals>
+          </execution>
+        </executions>
+      </plugin>
+    </plugins>
     <pluginManagement>
       <plugins>
         <plugin>

--- a/smile/src/test/java/module-info.java
+++ b/smile/src/test/java/module-info.java
@@ -23,4 +23,8 @@ module tools.jackson.jakarta.rs.smile
     opens tools.jackson.jakarta.rs.smile;
     opens tools.jackson.jakarta.rs.smile.dw;
     opens tools.jackson.jakarta.rs.smile.jersey;
+
+    // ServiceLoader tests
+    uses jakarta.ws.rs.ext.MessageBodyWriter;
+    uses jakarta.ws.rs.ext.MessageBodyReader;
 }

--- a/smile/src/test/java/tools/jackson/jakarta/rs/smile/ServiceLoaderIT.java
+++ b/smile/src/test/java/tools/jackson/jakarta/rs/smile/ServiceLoaderIT.java
@@ -1,0 +1,49 @@
+package tools.jackson.jakarta.rs.smile;
+
+import java.util.Comparator;
+import java.util.List;
+import java.util.ServiceLoader;
+import java.util.ServiceLoader.Provider;
+
+import jakarta.ws.rs.ext.MessageBodyReader;
+import jakarta.ws.rs.ext.MessageBodyWriter;
+
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+public class ServiceLoaderIT {
+    @Test
+    public void testMessageBodyWriter() {
+        @SuppressWarnings("rawtypes")
+        final List<MessageBodyWriter> providers = ServiceLoader
+            .load(MessageBodyWriter.class)
+            .stream()
+            .map(Provider<MessageBodyWriter>::get)
+            .toList();
+
+        assertEquals(providers
+            .stream()
+            .map(w -> w.getClass())
+            .sorted(Comparator.comparing(Class::getSimpleName)).toList(), List.of(
+                tools.jackson.jakarta.rs.smile.JacksonSmileProvider.class
+            ));
+    }
+
+    @Test
+    public void testMessageBodyReader() {
+        @SuppressWarnings("rawtypes")
+        final List<MessageBodyReader> providers = ServiceLoader
+            .load(MessageBodyReader.class)
+            .stream()
+            .map(Provider<MessageBodyReader>::get)
+            .toList();
+
+        assertEquals(providers
+            .stream()
+            .map(w -> w.getClass())
+            .sorted(Comparator.comparing(Class::getSimpleName)).toList(), List.of(
+                tools.jackson.jakarta.rs.smile.JacksonSmileProvider.class
+            ));
+    }
+}

--- a/xml/src/test/java/module-info.java
+++ b/xml/src/test/java/module-info.java
@@ -23,4 +23,8 @@ module tools.jackson.jakarta.rs.xml
     opens tools.jackson.jakarta.rs.xml;
     opens tools.jackson.jakarta.rs.xml.dw;
     opens tools.jackson.jakarta.rs.xml.jersey;
+
+    // ServiceLoader tests
+    uses jakarta.ws.rs.ext.MessageBodyWriter;
+    uses jakarta.ws.rs.ext.MessageBodyReader;
 }

--- a/xml/src/test/java/tools/jackson/jakarta/rs/xml/ServiceLoaderIT.java
+++ b/xml/src/test/java/tools/jackson/jakarta/rs/xml/ServiceLoaderIT.java
@@ -1,0 +1,49 @@
+package tools.jackson.jakarta.rs.xml;
+
+import java.util.Comparator;
+import java.util.List;
+import java.util.ServiceLoader;
+import java.util.ServiceLoader.Provider;
+
+import jakarta.ws.rs.ext.MessageBodyReader;
+import jakarta.ws.rs.ext.MessageBodyWriter;
+
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+public class ServiceLoaderIT {
+    @Test
+    public void testMessageBodyWriter() {
+        @SuppressWarnings("rawtypes")
+        final List<MessageBodyWriter> providers = ServiceLoader
+            .load(MessageBodyWriter.class)
+            .stream()
+            .map(Provider<MessageBodyWriter>::get)
+            .toList();
+
+        assertEquals(providers
+            .stream()
+            .map(w -> w.getClass())
+            .sorted(Comparator.comparing(Class::getSimpleName)).toList(), List.of(
+                tools.jackson.jakarta.rs.xml.JacksonXMLProvider.class
+            ));
+    }
+
+    @Test
+    public void testMessageBodyReader() {
+        @SuppressWarnings("rawtypes")
+        final List<MessageBodyReader> providers = ServiceLoader
+            .load(MessageBodyReader.class)
+            .stream()
+            .map(Provider<MessageBodyReader>::get)
+            .toList();
+
+        assertEquals(providers
+            .stream()
+            .map(w -> w.getClass())
+            .sorted(Comparator.comparing(Class::getSimpleName)).toList(), List.of(
+                tools.jackson.jakarta.rs.xml.JacksonXMLProvider.class
+            ));
+    }
+}

--- a/yaml/src/test/java/module-info.java
+++ b/yaml/src/test/java/module-info.java
@@ -28,4 +28,8 @@ module tools.jackson.jakarta.rs.yaml
     opens tools.jackson.jakarta.rs.yaml;
     opens tools.jackson.jakarta.rs.yaml.dw;
     opens tools.jackson.jakarta.rs.yaml.jersey;
+
+    // ServiceLoader tests
+    uses jakarta.ws.rs.ext.MessageBodyWriter;
+    uses jakarta.ws.rs.ext.MessageBodyReader;
 }

--- a/yaml/src/test/java/tools/jackson/jakarta/rs/yaml/ServiceLoaderIT.java
+++ b/yaml/src/test/java/tools/jackson/jakarta/rs/yaml/ServiceLoaderIT.java
@@ -1,0 +1,53 @@
+package tools.jackson.jakarta.rs.yaml;
+
+import java.util.Comparator;
+import java.util.List;
+import java.util.ServiceLoader;
+import java.util.ServiceLoader.Provider;
+
+import jakarta.ws.rs.ext.MessageBodyReader;
+import jakarta.ws.rs.ext.MessageBodyWriter;
+
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+public class ServiceLoaderIT {
+    @Test
+    public void testMessageBodyWriter() {
+        @SuppressWarnings("rawtypes")
+        final List<MessageBodyWriter> providers = ServiceLoader
+            .load(MessageBodyWriter.class)
+            .stream()
+            .map(Provider<MessageBodyWriter>::get)
+            .toList();
+
+        assertEquals(providers
+            .stream()
+            .map(w -> w.getClass())
+            .sorted(Comparator.comparing(Class::getSimpleName)).toList(), List.of(
+                tools.jackson.jakarta.rs.json.JacksonJsonProvider.class, 
+                tools.jackson.jakarta.rs.smile.JacksonSmileProvider.class,
+                tools.jackson.jakarta.rs.yaml.JacksonYAMLProvider.class
+            ));
+    }
+
+    @Test
+    public void testMessageBodyReader() {
+        @SuppressWarnings("rawtypes")
+        final List<MessageBodyReader> providers = ServiceLoader
+            .load(MessageBodyReader.class)
+            .stream()
+            .map(Provider<MessageBodyReader>::get)
+            .toList();
+
+        assertEquals(providers
+            .stream()
+            .map(w -> w.getClass())
+            .sorted(Comparator.comparing(Class::getSimpleName)).toList(), List.of(
+                tools.jackson.jakarta.rs.json.JacksonJsonProvider.class, 
+                tools.jackson.jakarta.rs.smile.JacksonSmileProvider.class,
+                tools.jackson.jakarta.rs.yaml.JacksonYAMLProvider.class
+            ));
+    }
+}


### PR DESCRIPTION
To verify against regression wrt https://github.com/FasterXML/jackson-jakarta-rs-providers/pull/57, it'd be great to have simple unit test(s) to instantiate providers using `ServiceLoader`. That should at least have caught specific problem of wrong Java package name for format backends.

Closes https://github.com/FasterXML/jackson-jakarta-rs-providers/issues/58