### PR TITLE
Add constructors accepting `[Format]MapperConfigurator` to providers

### DIFF
--- a/cbor/src/main/java/tools/jackson/jakarta/rs/cbor/JacksonCBORProvider.java
+++ b/cbor/src/main/java/tools/jackson/jakarta/rs/cbor/JacksonCBORProvider.java
@@ -102,6 +102,14 @@ extends ProviderBase<JacksonCBORProvider,
     }
 
     /**
+     * Constructor for use with a custom mapperConfigurator (usually implementing
+     * some methods from MapperConfiguratorBase)
+     */
+    public JacksonCBORProvider(CBORMapperConfigurator mapperConfigurator) {
+        super(mapperConfigurator);
+    }
+
+    /**
      * Method that will return version information stored in and read from jar
      * that contains this class.
      */

--- a/cbor/src/main/java/tools/jackson/jakarta/rs/cbor/JacksonCBORProvider.java
+++ b/cbor/src/main/java/tools/jackson/jakarta/rs/cbor/JacksonCBORProvider.java
@@ -104,6 +104,7 @@ extends ProviderBase<JacksonCBORProvider,
     /**
      * Constructor for use with a custom mapperConfigurator (usually implementing
      * some methods from MapperConfiguratorBase)
+     * @since 3.1
      */
     public JacksonCBORProvider(CBORMapperConfigurator mapperConfigurator) {
         super(mapperConfigurator);

--- a/cbor/src/main/java/tools/jackson/jakarta/rs/cbor/JacksonXmlBindCBORProvider.java
+++ b/cbor/src/main/java/tools/jackson/jakarta/rs/cbor/JacksonXmlBindCBORProvider.java
@@ -51,6 +51,14 @@ public class JacksonXmlBindCBORProvider extends JacksonCBORProvider
         super(mapper, aiOverride);
     }
 
+    /**
+     * Constructor for use with a custom mapperConfigurator (usually implementing
+     * some methods from MapperConfiguratorBase)
+     */
+    public JacksonXmlBindCBORProvider(CBORMapperConfigurator mapperConfigurator) {
+        super(mapperConfigurator);
+    }
+
     // Silly class to encapsulate reference to JAXB introspector class so that
     // loading of parent class does not require it; only happens if and when
     // introspector needed

--- a/cbor/src/main/java/tools/jackson/jakarta/rs/cbor/JacksonXmlBindCBORProvider.java
+++ b/cbor/src/main/java/tools/jackson/jakarta/rs/cbor/JacksonXmlBindCBORProvider.java
@@ -54,6 +54,7 @@ public class JacksonXmlBindCBORProvider extends JacksonCBORProvider
     /**
      * Constructor for use with a custom mapperConfigurator (usually implementing
      * some methods from MapperConfiguratorBase)
+     * @since 3.1
      */
     public JacksonXmlBindCBORProvider(CBORMapperConfigurator mapperConfigurator) {
         super(mapperConfigurator);

--- a/json/src/main/java/tools/jackson/jakarta/rs/json/JacksonJsonProvider.java
+++ b/json/src/main/java/tools/jackson/jakarta/rs/json/JacksonJsonProvider.java
@@ -116,6 +116,8 @@ public class JacksonJsonProvider
      * some methods from MapperConfiguratorBase)
      *
      * @param mapperConfigurator custom mapper configurator to use
+     *
+     * @since 3.1
      */
     public JacksonJsonProvider(JsonMapperConfigurator mapperConfigurator) {
         super(mapperConfigurator);

--- a/json/src/main/java/tools/jackson/jakarta/rs/json/JacksonJsonProvider.java
+++ b/json/src/main/java/tools/jackson/jakarta/rs/json/JacksonJsonProvider.java
@@ -112,6 +112,16 @@ public class JacksonJsonProvider
     }
 
     /**
+     * Constructor for use with a custom mapperConfigurator (usually implementing
+     * some methods from MapperConfiguratorBase)
+     *
+     * @param mapperConfigurator custom mapper configurator to use
+     */
+    public JacksonJsonProvider(JsonMapperConfigurator mapperConfigurator) {
+        super(mapperConfigurator);
+    }
+
+    /**
      * Method that will return version information stored in and read from jar
      * that contains this class.
      */

--- a/json/src/main/java/tools/jackson/jakarta/rs/json/JacksonXmlBindJsonProvider.java
+++ b/json/src/main/java/tools/jackson/jakarta/rs/json/JacksonXmlBindJsonProvider.java
@@ -51,6 +51,7 @@ public class JacksonXmlBindJsonProvider extends JacksonJsonProvider
     /**
      * Constructor for use with a custom mapperConfigurator (usually implementing
      * some methods from MapperConfiguratorBase)
+     * @since 3.1
      */
     public JacksonXmlBindJsonProvider(JsonMapperConfigurator mapperConfigurator) {
         super(mapperConfigurator);

--- a/json/src/main/java/tools/jackson/jakarta/rs/json/JacksonXmlBindJsonProvider.java
+++ b/json/src/main/java/tools/jackson/jakarta/rs/json/JacksonXmlBindJsonProvider.java
@@ -48,6 +48,14 @@ public class JacksonXmlBindJsonProvider extends JacksonJsonProvider
         super(mapper, aiOverride);
     }
 
+    /**
+     * Constructor for use with a custom mapperConfigurator (usually implementing
+     * some methods from MapperConfiguratorBase)
+     */
+    public JacksonXmlBindJsonProvider(JsonMapperConfigurator mapperConfigurator) {
+        super(mapperConfigurator);
+    }
+
     // Silly class to encapsulate reference to JAXB introspector class so that
     // loading of parent class does not require it; only happens if and when
     // introspector needed

--- a/release-notes/CREDITS
+++ b/release-notes/CREDITS
@@ -11,3 +11,8 @@ Andriy Redko (@reta)
 
 * Contributed #57: Fix ServiceLoader manifests due to 3.0 package changes
  [3.0.1]
+
+Jens-Otto Larsen (@jolarsen)
+
+* Contributed #63: Add constructors accepting `[Format]MapperConfigurator` to providers
+ [3.1.0]

--- a/release-notes/VERSION
+++ b/release-notes/VERSION
@@ -10,6 +10,11 @@ Sub-modules:
 === Releases ===
 ------------------------------------------------------------------------
 
+3.1.0 (not yet released)
+
+#63: Add constructors accepting `[Format]MapperConfigurator` to providers
+ (contributed by Jens-Otto L)
+
 3.0.3 (28-Nov-2025)
 3.0.2 (07-Nov-2025)
 

--- a/smile/src/main/java/tools/jackson/jakarta/rs/smile/JacksonSmileProvider.java
+++ b/smile/src/main/java/tools/jackson/jakarta/rs/smile/JacksonSmileProvider.java
@@ -110,6 +110,7 @@ extends ProviderBase<JacksonSmileProvider,
     /**
      * Constructor for use with a custom mapperConfigurator (usually implementing
      * some methods from MapperConfiguratorBase)
+     * @since 3.1
      */
     public JacksonSmileProvider(SmileMapperConfigurator mapperConfigurator) {
         super(mapperConfigurator);

--- a/smile/src/main/java/tools/jackson/jakarta/rs/smile/JacksonSmileProvider.java
+++ b/smile/src/main/java/tools/jackson/jakarta/rs/smile/JacksonSmileProvider.java
@@ -108,6 +108,14 @@ extends ProviderBase<JacksonSmileProvider,
     }
 
     /**
+     * Constructor for use with a custom mapperConfigurator (usually implementing
+     * some methods from MapperConfiguratorBase)
+     */
+    public JacksonSmileProvider(SmileMapperConfigurator mapperConfigurator) {
+        super(mapperConfigurator);
+    }
+
+    /**
      * Method that will return version information stored in and read from jar
      * that contains this class.
      */

--- a/smile/src/main/java/tools/jackson/jakarta/rs/smile/JacksonXmlBindSmileProvider.java
+++ b/smile/src/main/java/tools/jackson/jakarta/rs/smile/JacksonXmlBindSmileProvider.java
@@ -50,6 +50,7 @@ public class JacksonXmlBindSmileProvider extends JacksonSmileProvider
     /**
      * Constructor for use with a custom mapperConfigurator (usually implementing
      * some methods from MapperConfiguratorBase)
+     * @since 3.1
      */
     public JacksonXmlBindSmileProvider(SmileMapperConfigurator mapperConfigurator) {
         super(mapperConfigurator);

--- a/smile/src/main/java/tools/jackson/jakarta/rs/smile/JacksonXmlBindSmileProvider.java
+++ b/smile/src/main/java/tools/jackson/jakarta/rs/smile/JacksonXmlBindSmileProvider.java
@@ -47,6 +47,14 @@ public class JacksonXmlBindSmileProvider extends JacksonSmileProvider
         super(mapper, aiOverride);
     }
 
+    /**
+     * Constructor for use with a custom mapperConfigurator (usually implementing
+     * some methods from MapperConfiguratorBase)
+     */
+    public JacksonXmlBindSmileProvider(SmileMapperConfigurator mapperConfigurator) {
+        super(mapperConfigurator);
+    }
+
     // Silly class to encapsulate reference to JAXB introspector class so that
     // loading of parent class does not require it; only happens if and when
     // introspector needed

--- a/xml/src/main/java/tools/jackson/jakarta/rs/xml/JacksonXMLProvider.java
+++ b/xml/src/main/java/tools/jackson/jakarta/rs/xml/JacksonXMLProvider.java
@@ -95,6 +95,14 @@ public class JacksonXMLProvider
     }
 
     /**
+     * Constructor for use with a custom mapperConfigurator (usually implementing
+     * some methods from MapperConfiguratorBase)
+     */
+    public JacksonXMLProvider(XMLMapperConfigurator mapperConfigurator) {
+        super(mapperConfigurator);
+    }
+
+    /**
      * Method that will return version information stored in and read from jar
      * that contains this class.
      */

--- a/xml/src/main/java/tools/jackson/jakarta/rs/xml/JacksonXMLProvider.java
+++ b/xml/src/main/java/tools/jackson/jakarta/rs/xml/JacksonXMLProvider.java
@@ -97,6 +97,7 @@ public class JacksonXMLProvider
     /**
      * Constructor for use with a custom mapperConfigurator (usually implementing
      * some methods from MapperConfiguratorBase)
+     * @since 3.1
      */
     public JacksonXMLProvider(XMLMapperConfigurator mapperConfigurator) {
         super(mapperConfigurator);

--- a/xml/src/main/java/tools/jackson/jakarta/rs/xml/JacksonXmlBindXMLProvider.java
+++ b/xml/src/main/java/tools/jackson/jakarta/rs/xml/JacksonXmlBindXMLProvider.java
@@ -47,6 +47,14 @@ public class JacksonXmlBindXMLProvider extends JacksonXMLProvider
         super(mapper, aiOverride);
     }
 
+    /**
+     * Constructor for use with a custom mapperConfigurator (usually implementing
+     * some methods from MapperConfiguratorBase)
+     */
+    public JacksonXmlBindXMLProvider(XMLMapperConfigurator mapperConfigurator) {
+        super(mapperConfigurator);
+    }
+
     // Silly class to encapsulate reference to JAXB introspector class so that
     // loading of parent class does not require it; only happens if and when
     // introspector needed

--- a/xml/src/main/java/tools/jackson/jakarta/rs/xml/JacksonXmlBindXMLProvider.java
+++ b/xml/src/main/java/tools/jackson/jakarta/rs/xml/JacksonXmlBindXMLProvider.java
@@ -50,6 +50,7 @@ public class JacksonXmlBindXMLProvider extends JacksonXMLProvider
     /**
      * Constructor for use with a custom mapperConfigurator (usually implementing
      * some methods from MapperConfiguratorBase)
+     * @since 3.1
      */
     public JacksonXmlBindXMLProvider(XMLMapperConfigurator mapperConfigurator) {
         super(mapperConfigurator);

--- a/yaml/src/main/java/tools/jackson/jakarta/rs/yaml/JacksonXmlBindYAMLProvider.java
+++ b/yaml/src/main/java/tools/jackson/jakarta/rs/yaml/JacksonXmlBindYAMLProvider.java
@@ -51,6 +51,7 @@ public class JacksonXmlBindYAMLProvider extends JacksonYAMLProvider
     /**
      * Constructor for use with a custom mapperConfigurator (usually implementing
      * some methods from MapperConfiguratorBase)
+     * @since 3.1
      */
     public JacksonXmlBindYAMLProvider(YAMLMapperConfigurator mapperConfigurator) {
         super(mapperConfigurator);

--- a/yaml/src/main/java/tools/jackson/jakarta/rs/yaml/JacksonXmlBindYAMLProvider.java
+++ b/yaml/src/main/java/tools/jackson/jakarta/rs/yaml/JacksonXmlBindYAMLProvider.java
@@ -48,6 +48,14 @@ public class JacksonXmlBindYAMLProvider extends JacksonYAMLProvider
         super(mapper, aiOverride);
     }
 
+    /**
+     * Constructor for use with a custom mapperConfigurator (usually implementing
+     * some methods from MapperConfiguratorBase)
+     */
+    public JacksonXmlBindYAMLProvider(YAMLMapperConfigurator mapperConfigurator) {
+        super(mapperConfigurator);
+    }
+
     // Silly class to encapsulate reference to JAXB introspector class so that
     // loading of parent class does not require it; only happens if and when
     // introspector needed

--- a/yaml/src/main/java/tools/jackson/jakarta/rs/yaml/JacksonYAMLProvider.java
+++ b/yaml/src/main/java/tools/jackson/jakarta/rs/yaml/JacksonYAMLProvider.java
@@ -109,6 +109,7 @@ public class JacksonYAMLProvider
     /**
      * Constructor for use with a custom mapperConfigurator (usually implementing
      * some methods from MapperConfiguratorBase)
+     * @since 3.1
      */
     public JacksonYAMLProvider(YAMLMapperConfigurator mapperConfigurator) {
         super(mapperConfigurator);

--- a/yaml/src/main/java/tools/jackson/jakarta/rs/yaml/JacksonYAMLProvider.java
+++ b/yaml/src/main/java/tools/jackson/jakarta/rs/yaml/JacksonYAMLProvider.java
@@ -107,6 +107,14 @@ public class JacksonYAMLProvider
     }
 
     /**
+     * Constructor for use with a custom mapperConfigurator (usually implementing
+     * some methods from MapperConfiguratorBase)
+     */
+    public JacksonYAMLProvider(YAMLMapperConfigurator mapperConfigurator) {
+        super(mapperConfigurator);
+    }
+
+    /**
      * Method that will return version information stored in and read from jar
      * that contains this class.
      */


### PR DESCRIPTION
Extra constructor for Provider-classes to facilitate customizing MapperConfigurators - for instance implementing mapperBuilder() or _builderWithConfiguration() when no mapper is supplied (null).
This offers better support for immutable mappers and is preferrable to hacking _locateMapperViaProvider
This is similar to the PR in jackson-jaxrs-providers - and this is the PR we likely would like to proceed with