### PR TITLE
Fix #64: make "match anything" behavior configurable

### DIFF
--- a/base/src/main/java/tools/jackson/jakarta/rs/base/ProviderBase.java
+++ b/base/src/main/java/tools/jackson/jakarta/rs/base/ProviderBase.java
@@ -45,7 +45,7 @@ public abstract class ProviderBase<
      *  (why ClassKey? since plain old Class has no hashCode() defined,
      *  lookups are painfully slow)
      */
-    protected final static HashSet<ClassKey> DEFAULT_UNTOUCHABLES = new HashSet<ClassKey>();
+    protected final static HashSet<ClassKey> DEFAULT_UNTOUCHABLES = new HashSet<>();
     static {
         // First, I/O things (direct matches)
         DEFAULT_UNTOUCHABLES.add(new ClassKey(java.io.InputStream.class));

--- a/base/src/main/java/tools/jackson/jakarta/rs/cfg/JakartaRSFeature.java
+++ b/base/src/main/java/tools/jackson/jakarta/rs/cfg/JakartaRSFeature.java
@@ -100,7 +100,19 @@ public enum JakartaRSFeature implements ConfigFeature
     /* Other
     /**********************************************************************
      */
-    
+
+    /**
+     * [jaxrs-providers#162]: Feature that determines whether
+     * {@code hasMatchingMediaType()} will return {@code true} or {@code false}
+     * in cases where no Media-Type header passed.
+     *<p>
+     * NOTE: effective default before 3.1 was {@code true} but with 3.1 changes
+     * to explicit {@code false}, since this is considered likelier acceptable
+     * default setting.
+     *
+     * @since 3.1
+     */
+    MATCH_ALL_IF_NO_MEDIA_TYPE(false)
     ;
 
     private final boolean _defaultState;

--- a/cbor/src/main/java/tools/jackson/jakarta/rs/cbor/JacksonCBORProvider.java
+++ b/cbor/src/main/java/tools/jackson/jakarta/rs/cbor/JacksonCBORProvider.java
@@ -13,6 +13,7 @@ import tools.jackson.databind.*;
 import tools.jackson.dataformat.cbor.CBORMapper;
 
 import tools.jackson.jakarta.rs.base.ProviderBase;
+import tools.jackson.jakarta.rs.cfg.JakartaRSFeature;
 
 /**
  * Basic implementation of Jakarta-RS abstractions ({@link MessageBodyReader},
@@ -147,10 +148,9 @@ extends ProviderBase<JacksonCBORProvider,
             return CBORMediaTypes.APPLICATION_JACKSON_CBOR_TYPE.getSubtype().equalsIgnoreCase(subtype) || 
                     "cbor".equalsIgnoreCase(subtype) || subtype.endsWith("+cbor");
         }
-        /* Not sure if this can happen; but it seems reasonable
-         * that we can at least produce CBOR without media type?
-         */
-        return true;
+        // [jakarta-rs-providers#64]: Without a media type, may or may not match
+        // (if not, let JAX-RS deal with mapping if it can)
+        return isEnabled(JakartaRSFeature.MATCH_ALL_IF_NO_MEDIA_TYPE);
     }
 
     /**

--- a/json/src/main/java/tools/jackson/jakarta/rs/json/JacksonJsonProvider.java
+++ b/json/src/main/java/tools/jackson/jakarta/rs/json/JacksonJsonProvider.java
@@ -11,7 +11,6 @@ import tools.jackson.databind.*;
 import tools.jackson.databind.json.JsonMapper;
 import tools.jackson.jakarta.rs.base.ProviderBase;
 import tools.jackson.jakarta.rs.cfg.JakartaRSFeature;
-import tools.jackson.jaxrs.cfg.JaxRSFeature;
 
 /**
  * Basic implementation of Jakarta-RS abstractions ({@link MessageBodyReader},

--- a/json/src/main/java/tools/jackson/jakarta/rs/json/JacksonJsonProvider.java
+++ b/json/src/main/java/tools/jackson/jakarta/rs/json/JacksonJsonProvider.java
@@ -10,6 +10,8 @@ import tools.jackson.core.*;
 import tools.jackson.databind.*;
 import tools.jackson.databind.json.JsonMapper;
 import tools.jackson.jakarta.rs.base.ProviderBase;
+import tools.jackson.jakarta.rs.cfg.JakartaRSFeature;
+import tools.jackson.jaxrs.cfg.JaxRSFeature;
 
 /**
  * Basic implementation of Jakarta-RS abstractions ({@link MessageBodyReader},
@@ -177,9 +179,9 @@ public class JacksonJsonProvider
                    || "x-json".equals(subtype) // [Issue#40]
                    ;
         }
-        // Not sure if this can happen; but it seems reasonable
-        // that we can at least produce JSON without media type?
-        return true;
+        // [jakarta-rs-providers#64]: Without a media type, may or may not match
+        // (if not, let JAX-RS deal with mapping if it can)
+        return isEnabled(JakartaRSFeature.MATCH_ALL_IF_NO_MEDIA_TYPE);
     }
 
     @Override

--- a/release-notes/VERSION
+++ b/release-notes/VERSION
@@ -14,6 +14,7 @@ Sub-modules:
 
 #63: Add constructors accepting `[Format]MapperConfigurator` to providers
  (contributed by Jens-Otto L)
+#64: Fix errant “accept anything” handling of providers
 
 3.0.3 (28-Nov-2025)
 3.0.2 (07-Nov-2025)

--- a/smile/src/main/java/tools/jackson/jakarta/rs/smile/JacksonSmileProvider.java
+++ b/smile/src/main/java/tools/jackson/jakarta/rs/smile/JacksonSmileProvider.java
@@ -20,6 +20,7 @@ import tools.jackson.databind.ObjectWriter;
 import tools.jackson.dataformat.smile.SmileMapper;
 
 import tools.jackson.jakarta.rs.base.ProviderBase;
+import tools.jackson.jakarta.rs.cfg.JakartaRSFeature;
 
 /**
  * Basic implementation of Jakarta-RS abstractions ({@code MessageBodyReader},
@@ -153,10 +154,9 @@ extends ProviderBase<JacksonSmileProvider,
             return SmileMediaTypes.APPLICATION_JACKSON_SMILE_TYPE.getSubtype().equalsIgnoreCase(subtype) || 
                     "smile".equalsIgnoreCase(subtype) || subtype.endsWith("+smile");
         }
-        /* Not sure if this can happen; but it seems reasonable
-         * that we can at least produce smile without media type?
-         */
-        return true;
+        // [jakarta-rs-providers#64]: Without a media type, may or may not match
+        // (if not, let JAX-RS deal with mapping if it can)
+        return isEnabled(JakartaRSFeature.MATCH_ALL_IF_NO_MEDIA_TYPE);
     }
 
     /**

--- a/xml/src/main/java/tools/jackson/jakarta/rs/xml/JacksonXMLProvider.java
+++ b/xml/src/main/java/tools/jackson/jakarta/rs/xml/JacksonXMLProvider.java
@@ -14,6 +14,7 @@ import tools.jackson.databind.*;
 import tools.jackson.dataformat.xml.JacksonXmlAnnotationIntrospector;
 import tools.jackson.dataformat.xml.XmlMapper;
 import tools.jackson.jakarta.rs.base.ProviderBase;
+import tools.jackson.jakarta.rs.cfg.JakartaRSFeature;
 
 /**
  * Basic implementation of Jakarta-RS abstractions ({@link MessageBodyReader},
@@ -151,10 +152,9 @@ public class JacksonXMLProvider
             String subtype = mediaType.getSubtype();
             return "xml".equalsIgnoreCase(subtype) || subtype.endsWith("+xml");
         }
-        /* Not sure if this can happen; but it seems reasonable
-         * that we can at least produce XML without media type?
-         */
-        return true;
+        // [jakarta-rs-providers#64]: Without a media type, may or may not match
+        // (if not, let JAX-RS deal with mapping if it can)
+        return isEnabled(JakartaRSFeature.MATCH_ALL_IF_NO_MEDIA_TYPE);
     }
 
     /**

--- a/xml/src/test/java/tools/jackson/jakarta/rs/xml/TestUntouchables.java
+++ b/xml/src/test/java/tools/jackson/jakarta/rs/xml/TestUntouchables.java
@@ -1,5 +1,6 @@
 package tools.jackson.jakarta.rs.xml;
 
+import java.lang.annotation.Annotation;
 import java.util.*;
 
 import jakarta.ws.rs.core.MediaType;
@@ -39,15 +40,20 @@ public class TestUntouchables
     {
         JacksonXMLProvider prov = new JacksonXMLProvider();
         // By default, no reason to exclude, say, this test class...
-        assertTrue(prov.isReadable(getClass(), getClass(), null, null));
-        assertTrue(prov.isWriteable(getClass(), getClass(), null, null));
+        assertTrue(prov.isReadable(getClass(), getClass(),
+                new Annotation[0], MediaType.APPLICATION_XML_TYPE));
+        assertTrue(prov.isWriteable(getClass(), getClass(),
+                new Annotation[0], MediaType.APPLICATION_XML_TYPE));
 
         // but some types should be ignored (set of ignorable may change over time tho!)
-        assertFalse(prov.isWriteable(StreamingOutput.class, StreamingOutput.class, null, null));
+        assertFalse(prov.isWriteable(StreamingOutput.class, StreamingOutput.class,
+                new Annotation[0], MediaType.APPLICATION_XML_TYPE));
 
         // and then on-the-fence things (see [Issue-1])
-        assertFalse(prov.isReadable(String.class, getClass(), null, null));
-        assertFalse(prov.isReadable(byte[].class, getClass(), null, null));
+        assertFalse(prov.isReadable(String.class, getClass(),
+                new Annotation[0], MediaType.APPLICATION_XML_TYPE));
+        assertFalse(prov.isReadable(byte[].class, getClass(),
+                new Annotation[0], MediaType.APPLICATION_XML_TYPE));
     }
 
     @Test
@@ -57,13 +63,17 @@ public class TestUntouchables
         // can mark this as ignorable...
         prov.addUntouchable(getClass());
         // and then it shouldn't be processable
-        assertFalse(prov.isReadable(getClass(), getClass(), null, null));
-        assertFalse(prov.isWriteable(getClass(), getClass(), null, null));
+        assertFalse(prov.isReadable(getClass(), getClass(),
+                new Annotation[0], MediaType.APPLICATION_XML_TYPE));
+        assertFalse(prov.isWriteable(getClass(), getClass(),
+                new Annotation[0], MediaType.APPLICATION_XML_TYPE));
 
         // Same for interfaces, like:
         prov.addUntouchable(Collection.class);
-        assertFalse(prov.isReadable(ArrayList.class, ArrayList.class, null, null));
-        assertFalse(prov.isWriteable(HashSet.class, HashSet.class, null, null));
+        assertFalse(prov.isReadable(ArrayList.class, ArrayList.class,
+                new Annotation[0], MediaType.APPLICATION_XML_TYPE));
+        assertFalse(prov.isWriteable(HashSet.class, HashSet.class,
+                new Annotation[0], MediaType.APPLICATION_XML_TYPE));
     }
 }
     

--- a/yaml/src/main/java/tools/jackson/jakarta/rs/yaml/JacksonYAMLProvider.java
+++ b/yaml/src/main/java/tools/jackson/jakarta/rs/yaml/JacksonYAMLProvider.java
@@ -23,6 +23,7 @@ import tools.jackson.databind.ObjectWriter;
 import tools.jackson.dataformat.yaml.YAMLMapper;
 
 import tools.jackson.jakarta.rs.base.ProviderBase;
+import tools.jackson.jakarta.rs.cfg.JakartaRSFeature;
 
 /**
  * Basic implementation of Jakarta-RS abstractions ({@link MessageBodyReader},
@@ -162,10 +163,9 @@ public class JacksonYAMLProvider
             return "yaml".equalsIgnoreCase(subtype) || subtype.endsWith("+yaml");
             //tarik: apparently there is not a standard for yaml types, should be discussed
         }
-        /* Not sure if this can happen; but it seems reasonable
-         * that we can at least produce yaml without media type?
-         */
-        return true;
+        // [jakarta-rs-providers#64]: Without a media type, may or may not match
+        // (if not, let JAX-RS deal with mapping if it can)
+        return isEnabled(JakartaRSFeature.MATCH_ALL_IF_NO_MEDIA_TYPE);
     }
 
     /**

--- a/yaml/src/test/java/tools/jackson/jakarta/rs/yaml/TestUntouchables.java
+++ b/yaml/src/test/java/tools/jackson/jakarta/rs/yaml/TestUntouchables.java
@@ -1,5 +1,6 @@
 package tools.jackson.jakarta.rs.yaml;
 
+import java.lang.annotation.Annotation;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.HashSet;
@@ -18,6 +19,8 @@ import static org.junit.jupiter.api.Assertions.*;
 public class TestUntouchables
     extends JakartaRSTestBase
 {
+    private final static MediaType YAML_TYPE = YAMLMediaTypes.APPLICATION_JACKSON_YAML_TYPE;
+
     /**
      * Test type added for [JACKSON-460]... just to ensure that "isYAMLType"
      * remains overridable.
@@ -41,15 +44,20 @@ public class TestUntouchables
     {
         JacksonYAMLProvider prov = new JacksonYAMLProvider();
         // By default, no reason to exclude, say, this test class...
-        assertTrue(prov.isReadable(getClass(), getClass(), null, null));
-        assertTrue(prov.isWriteable(getClass(), getClass(), null, null));
+        assertTrue(prov.isReadable(getClass(), getClass(),
+                new Annotation[0], YAML_TYPE));
+        assertTrue(prov.isWriteable(getClass(), getClass(),
+                new Annotation[0], YAML_TYPE));
 
         // but some types should be ignored (set of ignorable may change over time tho!)
-        assertFalse(prov.isWriteable(StreamingOutput.class, StreamingOutput.class, null, null));
+        assertFalse(prov.isWriteable(StreamingOutput.class, StreamingOutput.class,
+                new Annotation[0], YAML_TYPE));
 
         // and then on-the-fence things (see [Issue-1])
-        assertFalse(prov.isReadable(String.class, getClass(), null, null));
-        assertFalse(prov.isReadable(byte[].class, getClass(), null, null));
+        assertFalse(prov.isReadable(String.class, getClass(),
+                new Annotation[0], YAML_TYPE));
+        assertFalse(prov.isReadable(byte[].class, getClass(),
+                new Annotation[0], YAML_TYPE));
     }
 
     @Test
@@ -59,13 +67,17 @@ public class TestUntouchables
         // can mark this as ignorable...
         prov.addUntouchable(getClass());
         // and then it shouldn't be processable
-        assertFalse(prov.isReadable(getClass(), getClass(), null, null));
-        assertFalse(prov.isWriteable(getClass(), getClass(), null, null));
+        assertFalse(prov.isReadable(getClass(), getClass(),
+                new Annotation[0], YAML_TYPE));
+        assertFalse(prov.isWriteable(getClass(), getClass(),
+                new Annotation[0], YAML_TYPE));
 
         // Same for interfaces, like:
         prov.addUntouchable(Collection.class);
-        assertFalse(prov.isReadable(ArrayList.class, ArrayList.class, null, null));
-        assertFalse(prov.isWriteable(HashSet.class, HashSet.class, null, null));
+        assertFalse(prov.isReadable(ArrayList.class, ArrayList.class,
+                new Annotation[0], YAML_TYPE));
+        assertFalse(prov.isWriteable(HashSet.class, HashSet.class,
+                new Annotation[0], YAML_TYPE));
     }
 }
     


### PR DESCRIPTION
Counterpart to https://github.com/FasterXML/jackson-jaxrs-providers/pull/162 on JAX-RS side.
