### PR TITLE
When a MappingIterator is used, ensure the current token is not the `START_ARRAY` token

### DIFF
--- a/base/src/main/java/tools/jackson/jakarta/rs/base/ProviderBase.java
+++ b/base/src/main/java/tools/jackson/jakarta/rs/base/ProviderBase.java
@@ -701,10 +701,11 @@ public abstract class ProviderBase<
 
         // 09-Jul-2015, tatu: As per [jaxrs-providers#69], handle MappingIterator too
         boolean multiValued = (rawType == MappingIterator.class);
-        
+        JavaType valueType = null;
+
         if (multiValued) {
             JavaType[] contents = tf.findTypeParameters(resolvedType, MappingIterator.class);
-            JavaType valueType = (contents == null || contents.length == 0)
+            valueType = (contents == null || contents.length == 0)
                     ? tf.constructType(Object.class) : contents[0];
             reader = reader.forType(valueType);
         } else {
@@ -718,11 +719,17 @@ public abstract class ProviderBase<
         }
         
         if (multiValued) {
-            // Clear START_ARRAY so MappingIterator will bind the array contents:
-            // readValues(JsonParser) uses managedParser=false, which does not auto-skip it.
-            // NOTE: must clear, not advance -- `MappingIterator` only detects END_ARRAY
-            // (that is, empty array) if the current token has been cleared.
-            if (p.currentToken() == JsonToken.START_ARRAY) {
+            // Clear START_ARRAY so MappingIterator will bind contents of the array,
+            // and not the array itself: `readValues(JsonParser)` requires caller to
+            // position parser past the wrapper array (it does not auto-skip it).
+            // NOTE: must clear, and not advance, token: `MappingIterator` only detects
+            // END_ARRAY (that is, empty array) if the current token has been cleared.
+            //
+            // But: leading START_ARRAY is ambiguous if values themselves are array-shaped
+            // (like "[1,2][3,4]" for `MappingIterator<int[]>`), in which case it starts
+            // the first value and must NOT be consumed.
+            if (!_isArrayShaped(valueType)
+                    && (p.currentToken() == JsonToken.START_ARRAY)) {
                 p.clearCurrentToken();
             }
             return reader.readValues(p);
@@ -869,6 +876,17 @@ public abstract class ProviderBase<
 
     protected NoContentException _createNoContentException() {
         return new NoContentException(NO_CONTENT_MESSAGE);
+    }
+
+    /**
+     * Overridable helper method called to check whether values of given type are
+     * themselves bound from JSON Arrays: if so, leading <code>START_ARRAY</code>
+     * of a value sequence starts the first value and may not be consumed as a
+     * wrapper array.
+     */
+    protected boolean _isArrayShaped(JavaType valueType) {
+        return (valueType != null)
+                && (valueType.isArrayType() || valueType.isCollectionLikeType());
     }
 
     /*

--- a/base/src/main/java/tools/jackson/jakarta/rs/base/ProviderBase.java
+++ b/base/src/main/java/tools/jackson/jakarta/rs/base/ProviderBase.java
@@ -885,8 +885,17 @@ public abstract class ProviderBase<
      * wrapper array.
      */
     protected boolean _isArrayShaped(JavaType valueType) {
-        return (valueType != null)
-                && (valueType.isArrayType() || valueType.isCollectionLikeType());
+        if (valueType == null) {
+            return false;
+        }
+        if (valueType.isArrayType()) {
+            // ... except that "binary" arrays are bound from JSON String (Base64-encoded),
+            // and `char[]` likewise from JSON String, and not from JSON Array
+            JavaType contentType = valueType.getContentType();
+            return !contentType.hasRawClass(Byte.TYPE)
+                    && !contentType.hasRawClass(Character.TYPE);
+        }
+        return valueType.isCollectionLikeType();
     }
 
     /*

--- a/base/src/main/java/tools/jackson/jakarta/rs/base/ProviderBase.java
+++ b/base/src/main/java/tools/jackson/jakarta/rs/base/ProviderBase.java
@@ -718,6 +718,11 @@ public abstract class ProviderBase<
         }
         
         if (multiValued) {
+            // Advance past START_ARRAY so MappingIterator sees the first element token.
+            // readValues(JsonParser) uses managedParser=false, which does not auto-skip it.
+            if (p.currentToken() == JsonToken.START_ARRAY) {
+                p.nextToken();
+            }
             return reader.readValues(p);
         }
         return reader.readValue(p);

--- a/base/src/main/java/tools/jackson/jakarta/rs/base/ProviderBase.java
+++ b/base/src/main/java/tools/jackson/jakarta/rs/base/ProviderBase.java
@@ -718,10 +718,12 @@ public abstract class ProviderBase<
         }
         
         if (multiValued) {
-            // Advance past START_ARRAY so MappingIterator sees the first element token.
+            // Clear START_ARRAY so MappingIterator will bind the array contents:
             // readValues(JsonParser) uses managedParser=false, which does not auto-skip it.
+            // NOTE: must clear, not advance -- `MappingIterator` only detects END_ARRAY
+            // (that is, empty array) if the current token has been cleared.
             if (p.currentToken() == JsonToken.START_ARRAY) {
-                p.nextToken();
+                p.clearCurrentToken();
             }
             return reader.readValues(p);
         }

--- a/json/src/test/java/tools/jackson/jakarta/rs/json/dw/SimpleEndpointTestBase.java
+++ b/json/src/test/java/tools/jackson/jakarta/rs/json/dw/SimpleEndpointTestBase.java
@@ -484,6 +484,44 @@ public abstract class SimpleEndpointTestBase extends ResourceTestBase
         assertEquals(4, p.y);
     }
 
+    /*
+        @Path("/max")
+        @POST
+        @Produces(MediaType.APPLICATION_JSON)
+        public Point maxPoint(MappingIterator<Point> points) throws IOException
+        {
+     */
+
+    @Test
+    public void testMappingIteratorArray() throws Exception
+    {
+        final ObjectMapper mapper = new JsonMapper();
+        Server server = startServer(TEST_PORT, SimpleResourceApp.class);
+        Point p;
+
+        try {
+            URL url = new URL("http://localhost:"+TEST_PORT+"/point/max");
+            HttpURLConnection conn = (HttpURLConnection) url.openConnection();
+            conn.setRequestProperty("Accept", MediaType.APPLICATION_JSON);
+            conn.setRequestProperty("Content-Type", MediaType.APPLICATION_JSON);
+            conn.setDoOutput(true);
+            conn.setRequestMethod("POST");
+            OutputStream out = conn.getOutputStream();
+            out.write(a2q("[{'x':1,'y':1},{'y':4,'x':-4},{'x':2,'y':5}]"
+            ).getBytes("UTF-8"));
+            out.close();
+            InputStream in = conn.getInputStream();
+            p = mapper.readValue(in, Point.class);
+            in.close();
+        } finally {
+            server.stop();
+        }
+        // ensure we got a valid Point
+        assertNotNull(p);
+        assertEquals(-4, p.x);
+        assertEquals(4, p.y);
+    }
+
     // [jakarta-rs-providers#16]
     @Test
     public void testPointNoTrailingContent() throws Exception

--- a/json/src/test/java/tools/jackson/jakarta/rs/json/dw/SimpleEndpointTestBase.java
+++ b/json/src/test/java/tools/jackson/jakarta/rs/json/dw/SimpleEndpointTestBase.java
@@ -218,6 +218,39 @@ public abstract class SimpleEndpointTestBase extends ResourceTestBase
             return new Point(count, sum);
         }
 
+        // Binary values are bound from JSON Strings, so wrapper array is to be
+        // unwrapped despite `byte[]` being an array type
+        @Path("/binary")
+        @POST
+        @Consumes(MediaType.APPLICATION_JSON)
+        @Produces(MediaType.APPLICATION_JSON)
+        public Point sumBinary(MappingIterator<byte[]> values) throws IOException
+        {
+            int count = 0;
+            int length = 0;
+            while (values.hasNextValue()) {
+                ++count;
+                length += values.nextValue().length;
+            }
+            return new Point(count, length);
+        }
+
+        // Same as "/sums" but with `Collection`-shaped, not array-shaped, values
+        @Path("/lists")
+        @POST
+        @Consumes(MediaType.APPLICATION_JSON)
+        @Produces(MediaType.APPLICATION_JSON)
+        public Point countPointLists(MappingIterator<List<Point>> values) throws IOException
+        {
+            int count = 0;
+            int points = 0;
+            while (values.hasNextValue()) {
+                ++count;
+                points += values.nextValue().size();
+            }
+            return new Point(count, points);
+        }
+
         @Path("/echo")
         @POST
         @Consumes(MediaType.APPLICATION_JSON)
@@ -465,14 +498,6 @@ public abstract class SimpleEndpointTestBase extends ResourceTestBase
         }
     }
 
-    /*
-        @Path("/max")
-        @POST
-        @Produces(MediaType.APPLICATION_JSON)
-        public Point maxPoint(MappingIterator<Point> points) throws IOException
-        {
-     */
-
     @Test
     public void testMappingIterator() throws Exception
     {
@@ -502,14 +527,6 @@ public abstract class SimpleEndpointTestBase extends ResourceTestBase
         assertEquals(-4, p.x);
         assertEquals(4, p.y);
     }
-
-    /*
-        @Path("/max")
-        @POST
-        @Produces(MediaType.APPLICATION_JSON)
-        public Point maxPoint(MappingIterator<Point> points) throws IOException
-        {
-     */
 
     @Test
     public void testMappingIteratorArray() throws Exception
@@ -596,6 +613,69 @@ public abstract class SimpleEndpointTestBase extends ResourceTestBase
         assertNotNull(p);
         assertEquals(2, p.x);
         assertEquals(10, p.y);
+    }
+
+    // Binary values bind from JSON String, so wrapper array is to be unwrapped
+    @Test
+    public void testMappingIteratorOfBinary() throws Exception
+    {
+        final ObjectMapper mapper = new JsonMapper();
+        Server server = startServer(TEST_PORT, SimpleResourceApp.class);
+        Point p;
+
+        try {
+            URL url = new URL("http://localhost:"+TEST_PORT+"/point/binary");
+            HttpURLConnection conn = (HttpURLConnection) url.openConnection();
+            conn.setRequestProperty("Accept", MediaType.APPLICATION_JSON);
+            conn.setRequestProperty("Content-Type", MediaType.APPLICATION_JSON);
+            conn.setDoOutput(true);
+            conn.setRequestMethod("POST");
+            OutputStream out = conn.getOutputStream();
+            // 2 Base64-encoded values, 3 bytes each
+            out.write(a2q("['AAEC','AwQF']").getBytes("UTF-8"));
+            out.close();
+            InputStream in = conn.getInputStream();
+            p = mapper.readValue(in, Point.class);
+            in.close();
+        } finally {
+            server.stop();
+        }
+        // 2 values, 6 bytes total
+        assertNotNull(p);
+        assertEquals(2, p.x);
+        assertEquals(6, p.y);
+    }
+
+    // Sequence of `Collection`-shaped values: leading START_ARRAY starts the
+    // first value and may not be skipped as a wrapper array
+    @Test
+    public void testMappingIteratorOfLists() throws Exception
+    {
+        final ObjectMapper mapper = new JsonMapper();
+        Server server = startServer(TEST_PORT, SimpleResourceApp.class);
+        Point p;
+
+        try {
+            URL url = new URL("http://localhost:"+TEST_PORT+"/point/lists");
+            HttpURLConnection conn = (HttpURLConnection) url.openConnection();
+            conn.setRequestProperty("Accept", MediaType.APPLICATION_JSON);
+            conn.setRequestProperty("Content-Type", MediaType.APPLICATION_JSON);
+            conn.setDoOutput(true);
+            conn.setRequestMethod("POST");
+            OutputStream out = conn.getOutputStream();
+            out.write(a2q("[{'x':1,'y':1},{'x':2,'y':2}][{'x':3,'y':3}]"
+                    ).getBytes("UTF-8"));
+            out.close();
+            InputStream in = conn.getInputStream();
+            p = mapper.readValue(in, Point.class);
+            in.close();
+        } finally {
+            server.stop();
+        }
+        // 2 values (Lists), 3 Points total
+        assertNotNull(p);
+        assertEquals(2, p.x);
+        assertEquals(3, p.y);
     }
 
     // [jakarta-rs-providers#16]

--- a/json/src/test/java/tools/jackson/jakarta/rs/json/dw/SimpleEndpointTestBase.java
+++ b/json/src/test/java/tools/jackson/jakarta/rs/json/dw/SimpleEndpointTestBase.java
@@ -522,6 +522,32 @@ public abstract class SimpleEndpointTestBase extends ResourceTestBase
         assertEquals(4, p.y);
     }
 
+    @Test
+    public void testMappingIteratorEmptyArray() throws Exception
+    {
+        Server server = startServer(TEST_PORT, SimpleResourceApp.class);
+        int responseCode;
+
+        try {
+            URL url = new URL("http://localhost:"+TEST_PORT+"/point/max");
+            HttpURLConnection conn = (HttpURLConnection) url.openConnection();
+            conn.setRequestProperty("Accept", MediaType.APPLICATION_JSON);
+            conn.setRequestProperty("Content-Type", MediaType.APPLICATION_JSON);
+            conn.setDoOutput(true);
+            conn.setRequestMethod("POST");
+            OutputStream out = conn.getOutputStream();
+            out.write("[ ]".getBytes("UTF-8"));
+            out.close();
+            responseCode = conn.getResponseCode();
+            conn.disconnect();
+        } finally {
+            server.stop();
+        }
+        // Empty array means no values to iterate over; endpoint returns `null`
+        // which Jakarta-RS maps to 204. Important part is that binding does NOT fail.
+        assertEquals(HttpURLConnection.HTTP_NO_CONTENT, responseCode);
+    }
+
     // [jakarta-rs-providers#16]
     @Test
     public void testPointNoTrailingContent() throws Exception

--- a/json/src/test/java/tools/jackson/jakarta/rs/json/dw/SimpleEndpointTestBase.java
+++ b/json/src/test/java/tools/jackson/jakarta/rs/json/dw/SimpleEndpointTestBase.java
@@ -199,6 +199,25 @@ public abstract class SimpleEndpointTestBase extends ResourceTestBase
             return max;
         }
 
+        // Values that are themselves array-shaped: leading START_ARRAY starts
+        // the first value, and must not be consumed as a wrapper array
+        @Path("/sums")
+        @POST
+        @Consumes(MediaType.APPLICATION_JSON)
+        @Produces(MediaType.APPLICATION_JSON)
+        public Point sumPoints(MappingIterator<int[]> values) throws IOException
+        {
+            int count = 0;
+            int sum = 0;
+            while (values.hasNextValue()) {
+                ++count;
+                for (int value : values.nextValue()) {
+                    sum += value;
+                }
+            }
+            return new Point(count, sum);
+        }
+
         @Path("/echo")
         @POST
         @Consumes(MediaType.APPLICATION_JSON)
@@ -546,6 +565,37 @@ public abstract class SimpleEndpointTestBase extends ResourceTestBase
         // Empty array means no values to iterate over; endpoint returns `null`
         // which Jakarta-RS maps to 204. Important part is that binding does NOT fail.
         assertEquals(HttpURLConnection.HTTP_NO_CONTENT, responseCode);
+    }
+
+    // Sequence of array-shaped values: leading START_ARRAY starts the first
+    // value and may not be skipped as a wrapper array
+    @Test
+    public void testMappingIteratorOfArrays() throws Exception
+    {
+        final ObjectMapper mapper = new JsonMapper();
+        Server server = startServer(TEST_PORT, SimpleResourceApp.class);
+        Point p;
+
+        try {
+            URL url = new URL("http://localhost:"+TEST_PORT+"/point/sums");
+            HttpURLConnection conn = (HttpURLConnection) url.openConnection();
+            conn.setRequestProperty("Accept", MediaType.APPLICATION_JSON);
+            conn.setRequestProperty("Content-Type", MediaType.APPLICATION_JSON);
+            conn.setDoOutput(true);
+            conn.setRequestMethod("POST");
+            OutputStream out = conn.getOutputStream();
+            out.write("[1,2][3,4]".getBytes("UTF-8"));
+            out.close();
+            InputStream in = conn.getInputStream();
+            p = mapper.readValue(in, Point.class);
+            in.close();
+        } finally {
+            server.stop();
+        }
+        // 2 values, sum of 10
+        assertNotNull(p);
+        assertEquals(2, p.x);
+        assertEquals(10, p.y);
     }
 
     // [jakarta-rs-providers#16]

--- a/release-notes/CREDITS
+++ b/release-notes/CREDITS
@@ -18,6 +18,7 @@ Jens-Otto Larsen (@jolarsen)
  [3.1.0]
 
 James R. Perkins (@jamezp)
+
 * Contributed #69: `ProviderBase.readFrom()` fails to advance past `START_ARRAY` for
   `MappingIterator` with JSON array input
- [3.1.0]
+ [3.3.0]

--- a/release-notes/CREDITS
+++ b/release-notes/CREDITS
@@ -16,3 +16,8 @@ Jens-Otto Larsen (@jolarsen)
 
 * Contributed #63: Add constructors accepting `[Format]MapperConfigurator` to providers
  [3.1.0]
+
+James R. Perkins (@jamezp)
+* Contributed #69: `ProviderBase.readFrom()` fails to advance past `START_ARRAY` for
+  `MappingIterator` with JSON array input
+ [3.1.0]

--- a/release-notes/VERSION
+++ b/release-notes/VERSION
@@ -12,7 +12,9 @@ Sub-modules:
 
 3.3.0 (not yet released)
 
-No changes since 3.2
+#69: `ProviderBase.readFrom()` fails to advance past `START_ARRAY` for
+  `MappingIterator` with JSON array input
+ (contributed by James P)
 
 3.2.1 (10-Jul-2026)
 


### PR DESCRIPTION
…It must be the next token per the `ObjectReader.readValues()` Javadoc.

resolves #69